### PR TITLE
Enable specifying the eg-iframe option in jsduck

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,6 +49,7 @@ Configuration
 |  title                 | The title to use for the documentation.                     |  ${project.name} ${project.version}     |
 |  header                | The header to use for the documentation.                    |  ${project.name} ${project.version} API |
 |  guides                | The guides to include                                       |                                         |
+|  egIframe              | Sample iframe for running inline examples                   |                                         |
 
 To change the configuration while running command line use the plugin name as prefix: -Djsduck.verbose=false.
 

--- a/maven-jsduck/pom.xml
+++ b/maven-jsduck/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.secondfloor.mojo.jsduck</groupId>
 	<artifactId>jsduck-maven-plugin</artifactId>
-	<version>0.1-SNAPSHOT</version>
+	<version>0.1.1-SNAPSHOT</version>
 	<name>jsduck-maven-plugin</name>
 	<description>Maven plugin for jsduck javascript document generation.</description>
 	<packaging>maven-plugin</packaging>

--- a/maven-jsduck/src/main/java/nl/secondfloor/mojo/jsduck/JsDuckMojo.java
+++ b/maven-jsduck/src/main/java/nl/secondfloor/mojo/jsduck/JsDuckMojo.java
@@ -97,6 +97,13 @@ public class JsDuckMojo extends AbstractMojo {
 	 */
 	private boolean builtinClasses;
 
+	/**
+	 * Location of example iframe used in the live preview feature
+	 *
+	 * @parameter
+	 */
+	private String egIframe;
+
 	public void execute() throws MojoExecutionException {
 		getLog().info("Producing JavaScript API documentation using jsduck.");
 		if (verbose) {
@@ -287,6 +294,7 @@ public class JsDuckMojo extends AbstractMojo {
 			jruby.put("title", title);
 			jruby.put("header", header);	
 			jruby.put("builtin_classes", builtinClasses);	
+			jruby.put("eg_iframe", egIframe);
 
 			jruby.runScriptlet(script);
 		} catch (IOException e) {

--- a/maven-jsduck/src/main/resources/maven_jsduck.rb
+++ b/maven-jsduck/src/main/resources/maven_jsduck.rb
@@ -27,6 +27,7 @@ if File.exists?(welcome_path)
 end
 options.title = title
 options.header = header
+options.eg_iframe = eg_iframe
 
 js_files = []
 # scan directory for .js files


### PR DESCRIPTION
Providing a custom eg-iframe is necessary in order to enable
live examples.

See https://github.com/senchalabs/jsduck/wiki/Inline-examples for why this is necessary. 

Note that this option already exists in jsduck and in the ruby options file, but was not being exposed in to the maven plugin. 

I followed the convention of using camelCase for the option in the xml.

I also bumped up the patch version number.

Sorry about making the pull request off master. I hadn't noticed that I was not on my topic branch until after pushing to github, and there is no easy way to undo that without causing a major headache.
