### PR TITLE
Fix the builtin classes option.

### DIFF
--- a/maven-jsduck/src/it/builtin/pom.xml
+++ b/maven-jsduck/src/it/builtin/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>nl.secondfloor.jsduck</groupId>
+	<artifactId>it</artifactId>
+	<version>0.1-SNAPSHOT</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>jsduck-api</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>jsduck</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<builtinClasses>true</builtinClasses>
+					<sources>
+						<source>src/main/webapp/js</source>
+						<source>src/main/js</source>
+					</sources>
+					<verbose>true</verbose>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/maven-jsduck/src/it/builtin/src/main/js/Jim.js
+++ b/maven-jsduck/src/it/builtin/src/main/js/Jim.js
@@ -1,0 +1,6 @@
+/*global Ext*/
+
+/**
+ * The basic Jim class
+ */
+Ext.define('Jim', {});

--- a/maven-jsduck/src/it/builtin/src/main/jsduck/welcome.html
+++ b/maven-jsduck/src/it/builtin/src/main/jsduck/welcome.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+	<h1>Flibble</h1>
+</body>
+</html>

--- a/maven-jsduck/src/it/builtin/src/main/webapp/js/Bob.js
+++ b/maven-jsduck/src/it/builtin/src/main/webapp/js/Bob.js
@@ -1,0 +1,6 @@
+/*global Ext*/
+
+/**
+ * The basic Bob class
+ */
+Ext.define('Bob', {});

--- a/maven-jsduck/src/it/builtin/verify.bsh
+++ b/maven-jsduck/src/it/builtin/verify.bsh
@@ -1,0 +1,54 @@
+import java.io.*;
+import org.codehaus.plexus.util.FileUtils;
+
+try
+{
+    File buildDir = new File( basedir, "target" );
+	
+    File bobFile = new File( new File(new File(buildDir, "jsduck-api"), "output"), "Bob.js");
+    if ( !bobFile.isFile()) {
+        System.err.println( bobFile.getAbsolutePath() + " file was not created" );
+        return false;
+    }
+
+    File jimFile = new File( new File(new File(buildDir, "jsduck-api"), "output"), "Jim.js");
+    if ( !jimFile.isFile()) {
+        System.err.println( jimFile.getAbsolutePath() + " file was not created" );
+        return false;
+    }
+
+    File arrayFile = new File( new File(new File(buildDir, "jsduck-api"), "output"), "Array.js");
+    if ( !arrayFile.isFile()) {
+        System.err.println( arrayFile.getAbsolutePath() + " file was not created" );
+        return false;
+    }
+
+    File index = new File(new File(buildDir, "jsduck-api"), "index.html");
+    if ( !index.isFile()) {
+        System.err.println( index.getAbsolutePath() + " file was not created" );
+        return false;
+    }
+    
+    BufferedReader r = new BufferedReader(new FileReader(index));
+    String l = null;
+    boolean flibble = false;
+    while ((l = r.readLine()) != null) {
+    	if (l.indexOf("Flibble") != -1) {
+    		flibble = true;
+    		break;
+    	}
+    }
+    if (!flibble) {
+    	System.err.println("Welcome page not honoured");
+    	return false;
+    }
+    
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;
+

--- a/maven-jsduck/src/main/resources/maven_jsduck.rb
+++ b/maven-jsduck/src/main/resources/maven_jsduck.rb
@@ -34,9 +34,15 @@ if footer && footer != ""
   options.footer = footer
 end
 
+input_path_array = input_path.to_a
+
+if(builtin_classes)
+	input_path_array << "target/js-classes"
+end
+
 js_files = []
 # scan directory for .js files
-  for d in input_path
+  for d in input_path_array
     if File.exists?(d)
       if File.directory?(d)
         Dir[d+"/**/*.{js,css,scss}"].each {|f| js_files << f }
@@ -48,10 +54,6 @@ js_files = []
     end
   end  
 options.input_files = js_files
-
-if(builtin_classes)
-	options.read_filenames("target/js-classes")
-end
 
 app = JsDuck::App.new(options)
 app.run()


### PR DESCRIPTION
Allow the built in JavaScript types to be documented again as this had stopped working. Also added an integration test for this.
